### PR TITLE
[ORG] RU-AXAV: When evaluating XPath on a context node, use the entire w3c document

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,11 @@ jsoup changelog
     useful when elements can only be distinguished by e.g. specific case, or leading whitespace, etc.
     <https://github.com/jhy/jsoup/issues/1636>
 
+  * Improvement: when evaluating an XPath query against a context element, the complete document is now visible to the
+    query, vs only the context element's sub-tree. This enables support for queries outside (parent or sibling) the
+    element, e.g. ancestor-or-self::*.
+    <https://github.com/jhy/jsoup/issues/1652>
+
 *** Release 1.14.3 [2021-Sep-30]
   * Improvement: added native XPath support in Element#selectXpath(String)
     <https://github.com/jhy/jsoup/pull/1629>

--- a/src/main/java/org/jsoup/nodes/NodeUtils.java
+++ b/src/main/java/org/jsoup/nodes/NodeUtils.java
@@ -44,7 +44,8 @@ final class NodeUtils {
 
         W3CDom w3c = new W3CDom();
         org.w3c.dom.Document wDoc = w3c.fromJsoup(el);
-        NodeList nodeList = w3c.selectXpath(xpath, wDoc);
+        org.w3c.dom.Node contextNode = w3c.contextNode(wDoc);
+        NodeList nodeList = w3c.selectXpath(xpath, contextNode);
         return w3c.sourceNodes(nodeList, nodeType);
     }
 }

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -328,7 +328,7 @@ public class W3CDomTest {
         Element jDiv = jdoc.selectFirst("div");
         assertNotNull(jDiv);
         Document doc = w3CDom.fromJsoup(jDiv);
-        Node div = doc.getFirstChild();
+        Node div = w3CDom.contextNode(doc);
 
         assertEquals("div", div.getLocalName());
         assertEquals(jDiv, div.getUserData(W3CDom.SourceProperty));

--- a/src/test/java/org/jsoup/select/XpathTest.java
+++ b/src/test/java/org/jsoup/select/XpathTest.java
@@ -43,13 +43,15 @@ public class XpathTest {
 
         Element div = doc.selectFirst("div");
         assertNotNull(div);
+        Element w3cDiv = div.selectXpath(".").first(); // self
+        assertSame(div, w3cDiv);
 
-        Elements els = div.selectXpath("/div/p");
+        Elements els = div.selectXpath("p");
         assertEquals(1, els.size());
         assertEquals("One", els.get(0).text());
         assertEquals("p", els.get(0).tagName());
 
-        assertEquals(0, div.selectXpath("//body").size());
+        assertEquals(1, div.selectXpath("//body").size()); // the whole document is visible on the div context
         assertEquals(1, doc.selectXpath("//body").size());
     }
 
@@ -144,6 +146,31 @@ public class XpathTest {
         assertEquals(2, hrefs.size());
         assertEquals("/foo", hrefs.get(0));
         assertEquals("/bar", hrefs.get(1));
+    }
+
+    @Test void selectOutsideOfElementTree() {
+        Document doc = Jsoup.parse("<p>One<p>Two<p>Three");
+        Elements ps = doc.selectXpath("//p");
+        assertEquals(3, ps.size());
+
+        Element p1 = ps.get(0);
+        assertEquals("One", p1.text());
+
+        Elements sibs = p1.selectXpath("following-sibling::p");
+        assertEquals(2, sibs.size());
+        assertEquals("Two", sibs.get(0).text());
+        assertEquals("Three", sibs.get(1).text());
+    }
+
+    @Test void selectAncestorsOnContextElement() {
+        // https://github.com/jhy/jsoup/issues/1652
+        Document doc = Jsoup.parse("<div><p>Hello");
+        Element p = doc.selectFirst("p");
+        assertNotNull(p);
+        Elements chain = p.selectXpath("ancestor-or-self::*");
+        assertEquals(4, chain.size());
+        assertEquals("html", chain.get(0).tagName());
+        assertEquals("p", chain.get(3).tagName());
     }
 
     @Test


### PR DESCRIPTION
And track the context in user data sections. This allows queries to evaluate against the complete document, vs just a sub-tree.

Fixes #1652